### PR TITLE
feat: add /metrics endpoint

### DIFF
--- a/cmd/dev-server/dev-server.go
+++ b/cmd/dev-server/dev-server.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"flag"
 	"fmt"
+	"github.com/ViBiOh/httputils/v4/pkg/prometheus"
 	"html/template"
 	"io/ioutil"
 	"log"
@@ -52,6 +54,14 @@ func main() {
 	router := mux.NewRouter().StrictSlash(true)
 	staticRouter := router.PathPrefix("/static/")
 	staticRouter.Handler(http.StripPrefix("/static/", http.FileServer(http.Dir("./web/static"))))
+
+	fs := flag.NewFlagSet("dev-server", flag.ExitOnError)
+	prometheusConfig := prometheus.Flags(fs, "prometheus")
+	prometheusApp := prometheus.New(prometheusConfig)
+
+	router.Handle("/metrics",  prometheusApp.Handler()).Methods(http.MethodGet)
+
+
 	router.HandleFunc("/reload", func(wr http.ResponseWriter, req *http.Request) {
 		if needsRefresh {
 			log.Println("Forcing reload")

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/17twenty/bizfi
 go 1.16
 
 require (
-	github.com/gofrs/uuid v4.0.0+incompatible
+	github.com/ViBiOh/httputils/v4 v4.22.3
+	github.com/gofrs/uuid v4.0.0+incompatible // indirect
 	github.com/gorilla/mux v1.8.0
 )


### PR DESCRIPTION
Add `/metrics` endpoint. For now it reports golang internal 